### PR TITLE
Adding option to dynamically resize the Scratch window.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Features
 --------
 
 + Scratch window automatically hides when inactive.
-+ Mappings allow easy note taking and selection pasting directly into the 
++ Mappings allow easy note taking and selection pasting directly into the
   scratch buffer.
 + Optional persistence across sessions.
 
@@ -22,25 +22,25 @@ Features
 Quickstart
 ----------
 
-+ `:Scratch` opens a scratch buffer in a new window (by default using the top 
-  20% of the screen, configurable via `g:scratch_height` and `g:scratch_top`). 
-  The window automatically closes when inactive (and its contents will be 
++ `:Scratch` opens a scratch buffer in a new window (by default using the top
+  20% of the screen, configurable via `g:scratch_height`, `g:scratch_auto_height` and `g:scratch_top`).
+  The window automatically closes when inactive (and its contents will be
   available the next time it is opened).
-+ `gs` in normal mode opens the scratch window and enters insert mode. The 
-  scratch window closes when you leave insert mode. This is especially useful 
++ `gs` in normal mode opens the scratch window and enters insert mode. The
+  scratch window closes when you leave insert mode. This is especially useful
   for quick notes.
-+ `gs` in visual mode pastes the current selection (character-wise, line-wise 
++ `gs` in visual mode pastes the current selection (character-wise, line-wise
   or block-wise) into the scratch buffer.
 
-Both above mappings have a `gS` variant that clears the scratch buffer before 
-opening it. Note also that the auto-closing features require `hidden` to be set 
+Both above mappings have a `gS` variant that clears the scratch buffer before
+opening it. Note also that the auto-closing features require `hidden` to be set
 (and can be disabled via the `g:scratch_autohide` option).
 
-By default the contents of the scratch window are lost when leaving Vim. To 
-enable cross-session persistence, set the `g:scratch_persistence_file` option 
+By default the contents of the scratch window are lost when leaving Vim. To
+enable cross-session persistence, set the `g:scratch_persistence_file` option
 to a valid file path.
 
-See `:help Scratch` for the full list of configuration options and more details 
+See `:help Scratch` for the full list of configuration options and more details
 on each.
 
 

--- a/autoload/scratch.vim
+++ b/autoload/scratch.vim
@@ -19,12 +19,13 @@ function! s:deactivate_autocmds()
 endfunction
 
 function! s:open_window(position)
+  let l:size = s:resolve_size(g:scratch_height)
   " open scratch buffer window and move to it. this will create the buffer if
   " necessary.
   let scr_bufnr = bufnr('__Scratch__')
   if scr_bufnr == -1
     let cmd = g:scratch_horizontal ? 'new' : 'vnew'
-    execute a:position . s:resolve_size(g:scratch_height) . cmd . ' __Scratch__'
+    execute a:position . l:size . cmd . ' __Scratch__'
     execute 'setlocal filetype=' . g:scratch_filetype
     setlocal bufhidden=hide
     setlocal nobuflisted
@@ -53,9 +54,17 @@ function! s:open_window(position)
       endif
     else
       let cmd = g:scratch_horizontal ? 'split' : 'vsplit'
-      execute a:position . s:resolve_size(g:scratch_height) . cmd . ' +buffer' . scr_bufnr
+      execute a:position . l:size . cmd . ' +buffer' . scr_bufnr
     endif
   endif
+
+  if g:scratch_auto_height
+    let l:dynamic_height = line('$')
+    if l:dynamic_height < l:size
+      execute ':resize '.l:dynamic_height
+    endif
+  endif
+
 endfunction
 
 function! s:close_window(force)

--- a/doc/scratch.txt
+++ b/doc/scratch.txt
@@ -16,9 +16,10 @@ CONTENTS                                                     *ScratchContents*
       3.3 |g:scratch_disable|
       3.4 |g:scratch_filetype|
       3.5 |g:scratch_height|
-      3.6 |g:scratch_top|
-      3.7 |g:scratch_horizontal|
-      3.8 |g:scratch_persistence_file|
+      3.6 |g:scratch_auto_height|
+      3.7 |g:scratch_top|
+      3.8 |g:scratch_horizontal|
+      3.9 |g:scratch_persistence_file|
     4. Mappings ........................ |ScratchMappings|
     5. Changes .......................... |ScratchChanges|
 
@@ -37,19 +38,19 @@ Unobtrusive scratch buffer.
 
 Open scratch buffer. With [!], also clear scratch buffer.
 
-See |g:scratch_autohide|, |g:scratch_insert_autohide|, |g:scratch_height|, and 
+See |g:scratch_autohide|, |g:scratch_insert_autohide|, |g:scratch_height|, and
 |g:scratch_top| for possible configuration options.
 
 
 ------------------------------------------------------------------------------
 2.2 :ScratchInsert[!]                               *:ScratchInsert* *gs* *gS*
 
-Open scratch buffer and go directly into insert mode. When open with this 
-command, the scratch buffer will also automatically close after leaving insert 
-mode (independent of |g:scratch_autohide|). If you don't want to close 
+Open scratch buffer and go directly into insert mode. When open with this
+command, the scratch buffer will also automatically close after leaving insert
+mode (independent of |g:scratch_autohide|). If you don't want to close
 automatically, see |g:scratch_insert_autohide|.
 
-With [!] or when using the |gS| mapping, the buffer will also be cleared before 
+With [!] or when using the |gS| mapping, the buffer will also be cleared before
 opening.
 
 
@@ -58,14 +59,14 @@ opening.
 
 Open scratch buffer and append current selection.
 
-With [!] or when using the |v_gS| mapping, the buffer will also be cleared 
+With [!] or when using the |v_gS| mapping, the buffer will also be cleared
 before opening.
 
 
 ------------------------------------------------------------------------------
 2.4 :ScratchPreview                                          *:ScratchPreview*
 
-Toggle scratch buffer and keep cursor in current window. If called from the 
+Toggle scratch buffer and keep cursor in current window. If called from the
 scratch buffer, close it.
 
 
@@ -75,7 +76,7 @@ scratch buffer, close it.
 ------------------------------------------------------------------------------
 3.1 g:scratch_autohide = &hidden                          *g:scratch_autohide*
 
-Automatically close scratch buffer window when leaving said scratch buffer. 
+Automatically close scratch buffer window when leaving said scratch buffer.
 Also allows Vim to quit when the scratch buffer is the last one displayed.
 
 
@@ -100,28 +101,35 @@ Scratch window filetype. Useful for example for syntax highlighting.
 ------------------------------------------------------------------------------
 3.5 g:scratch_height = 10                                   *g:scratch_height*
 
-Height (or width, if |g:scratch_horizontal| is set to 0) of the scratch window. 
-If a float is specified, it will be assumed to mean that fraction of the 
+Height (or width, if |g:scratch_horizontal| is set to 0) of the scratch window.
+If a float is specified, it will be assumed to mean that fraction of the
 currently open window.
 
 
 ------------------------------------------------------------------------------
-3.6 g:scratch_top = 1                                          *g:scratch_top*
+3.6 g:scratch_auto_height = 0                                   *g:scratch_auto_height*
 
-Open scratch window at the top of the screen instead of at the bottom. If 
-|g:scratch_horizontal| is set, this option will create the scratch window on 
+Sets the height of the scratch window dynamically to the number of lines in
+the scratch window. The maximum number of lines equals |g:scratch_height|.
+Only works when |g:scratch_horizontal| is set to 1.
+
+------------------------------------------------------------------------------
+3.7 g:scratch_top = 1                                          *g:scratch_top*
+
+Open scratch window at the top of the screen instead of at the bottom. If
+|g:scratch_horizontal| is set, this option will create the scratch window on
 the left side.
 
 
 ------------------------------------------------------------------------------
-3.7 g:scratch_horizontal = 1                            *g:scratch_horizontal*
+3.8 g:scratch_horizontal = 1                            *g:scratch_horizontal*
 
-Open the scratch window in a horizontal split instead of a vertical one (see 
+Open the scratch window in a horizontal split instead of a vertical one (see
 also |g:scratch_top| to configure the position of the new window).
 
 
 ------------------------------------------------------------------------------
-3.8 g:scratch_persistence_file = ''               *g:scratch_persistence_file*
+3.9 g:scratch_persistence_file = ''               *g:scratch_persistence_file*
 
 If set to a valid file path the scratch window contents will be written to
 that path whenever the scratch window gets hidden. Contents won't be lost
@@ -165,7 +173,7 @@ And set your favorite keys like below: >
   + Add |g:scratch_horizontal| option.
 
 2.0 (03/04/2015)
-  + Improve window auto-closing handling to allow for other autocommands to be 
+  + Improve window auto-closing handling to allow for other autocommands to be
     run.
 
 1.4 (12/09/2014)

--- a/plugin/scratch.vim
+++ b/plugin/scratch.vim
@@ -25,6 +25,9 @@ endif
 if !exists('g:scratch_persistence_file')
   let g:scratch_persistence_file = ''
 endif
+if !exists('g:scratch_auto_height') || g:scratch_horizontal == 0
+  let g:scratch_auto_height = 0
+endif
 
 command! -bang -nargs=0 Scratch call scratch#open(<bang>0)
 command! -bang -nargs=0 ScratchInsert call scratch#insert(<bang>0)


### PR DESCRIPTION
Especially when using `:ScratchPreview` and keeping it open with just a few lines in the buffer I was annoyed by the wasted space.

The PR enables dynamic window resizing to the number of lines in the scratch buffer, capped at `g:scratch_height` (only if `g:scratch_horizontal` is disabled).

