### PR TITLE
force write command for scratch persistence file

### DIFF
--- a/autoload/scratch.vim
+++ b/autoload/scratch.vim
@@ -61,7 +61,7 @@ endfunction
 function! s:close_window(force)
   " close scratch window if it is the last window open, or if force
   if strlen(g:scratch_persistence_file) > 0
-    execute ':w ' . g:scratch_persistence_file
+    execute ':w! ' . g:scratch_persistence_file
   endif
   if a:force
     let prev_bufnr = bufnr('#')


### PR DESCRIPTION
When a persistence file and autoclose are both set, Vim will complain when trying to write to the persistence file:

```
Error detected while processing WinLeave Autocommands for "<buffer=3>"..function <SNR>100_close_window:
line    3:
E13: File exists (add ! to override)
Press ENTER or type command to continue
```

I added the magic ❗ and it appears to work for me.

(thanks for the plugin, by the way!)